### PR TITLE
Add missing namespaces manifest

### DIFF
--- a/namespaces.yaml
+++ b/namespaces.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    environment: production
+  name: production
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    environment: staging
+  name: staging


### PR DESCRIPTION
Hello Viktor!

This commit adds the missing `namespaces.yaml` file referenced in line 39 of https://gist.github.com/vfarcic/f67624c05df3d949c8d9a6976adb4631